### PR TITLE
Add meta tags for mobile rendering

### DIFF
--- a/public/examples/hotel-booking/index.html
+++ b/public/examples/hotel-booking/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
   <link media="all" rel="stylesheet" href="../../css/bootstrap.min.css">
   <link media="all" rel="stylesheet" href="../../css/custom.css">
 </head>

--- a/public/examples/restaurant-reservation/index.html
+++ b/public/examples/restaurant-reservation/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
   <link media="all" rel="stylesheet" href="../../css/bootstrap.min.css">
   <link media="all" rel="stylesheet" href="../../css/custom.css">
 </head>

--- a/public/examples/service-subscription/index.html
+++ b/public/examples/service-subscription/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
   <link media="all" rel="stylesheet" href="../../css/bootstrap.min.css">
   <link media="all" rel="stylesheet" href="../../css/custom.css">
 </head>


### PR DESCRIPTION
Add meta tags to examples so that the conv extensions render properly in Android and iOS webviews

## before

![before](https://user-images.githubusercontent.com/2432382/41438584-bf9990da-6ff5-11e8-95c2-4840ddd98815.gif)

## after

![after](https://user-images.githubusercontent.com/2432382/41438592-c1f07ccc-6ff5-11e8-9a4a-021142a3d24d.gif)